### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,6 @@
 name: Rust
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/adayoung/ada-pastebin/security/code-scanning/2](https://github.com/adayoung/ada-pastebin/security/code-scanning/2)

To fix this issue, add an explicit `permissions:` block to restrict the token's permissions. Since the workflow as shown simply builds and tests Rust code and does not need to write to the repository or open issues or PRs, we can safely restrict permissions to `contents: read`. The most secure and maintainable place is at the root of the workflow file so that all jobs inherit this restriction unless they need additional privileges. Insert the following block after the `name:` field and before `on:` at the top of `.github/workflows/rust.yml`:

```yaml
permissions:
  contents: read
```
This ensures that the workflow (and all jobs inside) has the least privilege by default.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
